### PR TITLE
Custom view

### DIFF
--- a/app/overrides/issues/show.rb
+++ b/app/overrides/issues/show.rb
@@ -1,5 +1,6 @@
 Deface::Override.new :virtual_path => 'issues/show',
                      :original     => 'ee65ebb813ba3bbf55bc8dc6279f431dbb405c48',
                      :name         => 'show-projects-in-issue-description',
-                     :insert_after => '.attributes',
+                     #:insert_after => '.attributes',
+                     :insert_after => '#relations',
                      :partial         => 'issues/show_projects'

--- a/app/views/issues/_projects_list.html.erb
+++ b/app/views/issues/_projects_list.html.erb
@@ -8,7 +8,7 @@
   <span id="list_of_projects_per_issue">
     <% issue_projects.each do |project| %>
       <% if allowed_projects.include?(project) %>
-        <%= content_tag("span", link_to(project.name.gsub(/ /,"&nbsp;").html_safe, project_issues_path(project)), class: "list_projects_names") %>
+        <%= content_tag("span", link_to(project.name.gsub(/ /,"&nbsp;").html_safe, project_issues_path(project))) %>
         <% nb_visible_projects += 1 %>
       <% else %>
         <% nb_other_projects += 1 %>

--- a/app/views/issues/_show_projects.html.erb
+++ b/app/views/issues/_show_projects.html.erb
@@ -1,5 +1,5 @@
 <% if (@issue.projects-[@issue.project]).present? %>
-  <hr>
+  <hr></hr>
   <div id="current_projects_list" style="display: flex;">
     <span id="label_concerned_projects"><%= l("concerned_projects") %></span><%= render 'projects_list' %>
   </div>

--- a/assets/stylesheets/multiprojects_issue.css
+++ b/assets/stylesheets/multiprojects_issue.css
@@ -28,7 +28,7 @@ a.list_projects_names.current{
     font-weight: bold;
     display: inline-block;
     /* vertical-align: super; */
-    margin-top: 4px;
+    /* margin-top: 4px; */
 }
 
 .projects_container{

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,6 @@
 # English strings go here for Rails i18n
 en:
-  concerned_projects: "Impacted projects"
+  concerned_projects: "Related projects"
   modify_projects: "Edit projects list"
   select_none: "None"
   select_all: "All"
@@ -13,6 +13,6 @@ en:
   text_journal_project_deleted: "deleted project"
   text_journal_project_added: "added project"
   label_hide_details: "hide"
-  field_projects: "Impacted projects"
+  field_projects: "Related projects"
   field_answers_on_secondary_projects: "Answers allowed"
   multiprojects_selection_available_custom_fields: "Available custom fields to quickly select projects"


### PR DESCRIPTION
Hi @nanego 

Thanks for this plugin!

I've made a few changes, which I needed for our existing redmine workflow, mainly:

> We already use redmine's `Related issues`, hence,
> - it really makes sense to have this feature be labelled as: `Related projects`,
> - and to display them right next to each other on the Issues view.

I'm making the pull-request in case you think this could be a better `default look & style` for `redmine_multiprojects_issue` plugin, no obligation, thanks ;)
