### PR TITLE
Changed label to 'Related projects'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,6 @@
 # English strings go here for Rails i18n
 en:
-  concerned_projects: "Impacted projects"
+  concerned_projects: "Related projects"
   modify_projects: "Edit projects list"
   select_none: "None"
   select_all: "All"
@@ -13,6 +13,6 @@ en:
   text_journal_project_deleted: "deleted project"
   text_journal_project_added: "added project"
   label_hide_details: "hide"
-  field_projects: "Impacted projects"
+  field_projects: "Related projects"
   field_answers_on_secondary_projects: "Answers allowed"
   multiprojects_selection_available_custom_fields: "Available custom fields to quickly select projects"


### PR DESCRIPTION
Changed the label to `Related projects`, as it fits in better with redmine's existing `Related issues` section label.

@nanego - let me know if you want help/assistance in getting the other locales for the plugin to also match redmine's `Related issues` locales