### PR TITLE
Switch from redmine_base_deface plugin to redmine_plugin_kit gem

### DIFF
--- a/.github/workflows/4_1_5.yml
+++ b/.github/workflows/4_1_5.yml
@@ -112,12 +112,6 @@ jobs:
           bundle exec rake db:create db:migrate
           bundle exec rails test:scm:setup:subversion
 
-      - name: Checkout dependencies - Base Deface plugin
-        uses: actions/checkout@v2
-        with:
-          repository: jbbarth/redmine_base_deface
-          path: redmine/plugins/redmine_base_deface
-
       - name: Checkout dependencies - Base StimulusJS plugin
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/4_2_3.yml
+++ b/.github/workflows/4_2_3.yml
@@ -112,12 +112,6 @@ jobs:
           bundle exec rake db:create db:migrate
           bundle exec rails test:scm:setup:subversion
 
-      - name: Checkout dependencies - Base Deface plugin
-        uses: actions/checkout@v2
-        with:
-          repository: jbbarth/redmine_base_deface
-          path: redmine/plugins/redmine_base_deface
-
       - name: Checkout dependencies - Base StimulusJS plugin
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -112,12 +112,6 @@ jobs:
           bundle exec rake db:create db:migrate
           bundle exec rails test:scm:setup:subversion
 
-      - name: Checkout dependencies - Base Deface plugin
-        uses: actions/checkout@v2
-        with:
-          repository: jbbarth/redmine_base_deface
-          path: redmine/plugins/redmine_base_deface
-
       - name: Checkout dependencies - Base StimulusJS plugin
         uses: actions/checkout@v2
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'redmine_plugin_kit'

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Please apply general instructions for plugins [here](http://www.redmine.org/wiki
 
 Note that this plugin now depends on:
 
-* **redmine_base_deface** which can be found [here](https://github.com/jbbarth/redmine_base_deface)
 * **redmine_base_stimulusjs** which can be found [here](https://github.com/nanego/redmine_base_stimulusjs)
 
 These plugins must be installed first.
@@ -51,7 +50,7 @@ And finally restart your Redmine instance.
 
 |Plugin branch| Redmine Version   | Test Status      |
 |-------------|-------------------|------------------|
-|master       | 4.2.3             | [![4.2.3][1]][5] |  
+|master       | 4.2.3             | [![4.2.3][1]][5] |
 |master       | 4.1.5             | [![4.1.5][2]][5] |
 |master       | master            | [![master][4]][5]|
 

--- a/init.rb
+++ b/init.rb
@@ -19,7 +19,6 @@ Redmine::Plugin.register :redmine_multiprojects_issue do
   version '4.1.1'
   url 'https://github.com/nanego/redmine_multiprojects_issue'
   author_url 'mailto:contact@vincent-robert.com'
-  requires_redmine_plugin :redmine_base_deface, :version_or_higher => '0.0.1'
   requires_redmine_plugin :redmine_base_stimulusjs, :version_or_higher => '1.0.1'
   settings :default => { 'custom_fields' => []},
            :partial => 'settings/redmine_plugin_multiprojects_issue_settings'


### PR DESCRIPTION
To get more compatibility with other plugins, it would be great to use [redmine_plugin_kit](https://github.com/AlphaNodes/redmine_plugin_kit) Gem instead of [redmine_base_deface](https://github.com/jbbarth/redmine_base_deface) plugin. This would also be easier for users, because they do not have to manually install another plugin.

redmine_plugin_kit just provides the required deface gem and path for overwrites (as redmine_base_deface). All plugins which uses redmine_plugin_kit will get the same version of deface from this Gem.

I do not use redmine_base_deface plugin, because users have to make one more step (which can cause more support).

It would be great, if this patch would be merged.

PS: another reason to switch to the Gem is Rails 6.1 / Zeitwerk support. Latest Redmine patches do not work with deface, if Rails.application.paths is not added with application start.