### PR TITLE
fix : linking projects to an issue requires the correct permission

### DIFF
--- a/lib/redmine_multiprojects_issue/issues_controller_patch.rb
+++ b/lib/redmine_multiprojects_issue/issues_controller_patch.rb
@@ -22,13 +22,15 @@ class IssuesController < ApplicationController
   private
 
     def set_assignable_projects
+      if !User.current.admin? && !User.current.allowed_to?(:link_other_projects_to_issue, @issue.project)
+        @issue.assignable_projects = @issue.projects
+        return
+      end
       if params[:issue] && params[:issue][:project_ids]
         @projects = []
         params[:issue][:project_ids].reject!(&:blank?)
         if params[:issue][:project_ids].present?
           Project.find(params[:issue][:project_ids]).each do |p|
-            # next unless User.current.allowed_to?(:add_issues, p)
-
             @projects << p unless (params[:project_id] == p.id.to_s || params[:issue][:project_id]  == p.id.to_s)
           end
         end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -132,6 +132,25 @@ describe IssuesController, type: :controller do
     expect(issue.project_ids).to be_empty
   end
 
+  it "should keep current current linked projects when user has no permission" do
+    Role.find_by_name("Manager").remove_permission!(:link_other_projects_to_issue)
+    @request.session[:user_id] = 2
+
+    issue = Issue.find(1)
+    issue.assignable_projects = [Project.first]
+    issue.save!
+
+    put :update, params: {:id => 1, :issue => {:subject => "new subject",
+                                               :priority_id => '6',
+                                               :project_ids => [1, 5],
+                                               :category_id => '1' 
+    }}
+    issue.reload
+
+    expect(issue.subject).to eq("new subject")
+    expect(issue.project_ids).to eq([1])
+  end
+
   it "should put update should send a notification to members on other projects" do
     @request.session[:user_id] = 2
     ActionMailer::Base.deliveries.clear

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -36,6 +36,29 @@ describe IssuesController, type: :controller do
            :changesets,
            :projects
 
+  before(:each) do
+    Role.find_by_name("Manager").add_permission!(:link_other_projects_to_issue)
+  end
+
+  it "should require correct permission when linking other projects during issue creation (:link_other_projects_to_issue)" do
+    Role.find_by_name("Manager").remove_permission!(:link_other_projects_to_issue)
+    ActionMailer::Base.deliveries.clear
+    @request.session[:user_id] = 2
+
+    assert_difference 'Issue.count', 1 do
+      post :create, params: {:project_id => 1,
+                              :issue => {:tracker_id => 3,
+                                        :subject => 'This is the test_new issue',
+                                        :description => 'This is the description',
+                                        :priority_id => 5,
+                                        :estimated_hours => '',
+                                        :project_ids => [1, 5, 2],
+                                        :custom_field_values => {'2' => 'Value for field 2'}}}
+    end
+
+    expect(Issue.last.project_ids).to be_empty
+  end
+
   it "should post create should send a notification to other projects users" do
     ActionMailer::Base.deliveries.clear
     @request.session[:user_id] = 2
@@ -86,6 +109,27 @@ describe IssuesController, type: :controller do
     expect(notified_users).to include(User.find(3).mail)
     expect(notified_users).to_not include(User.find(1).mail)
     expect(notified_users).to_not include(User.find(8).mail)
+  end
+
+  it "should require correct permission when linking other projects during issue update" do
+    Role.find_by_name("Manager").remove_permission!(:link_other_projects_to_issue)
+
+    @request.session[:user_id] = 2
+    ActionMailer::Base.deliveries.clear
+    issue = Issue.find(1)
+    old_subject = issue.subject
+    new_subject = 'Subject modified by IssuesControllerTest#test_post_edit'
+
+    put :update, params: {:id => 1, :issue => {:subject => new_subject,
+                                               :priority_id => '6',
+                                               :project_ids => [1, 5],
+                                               :category_id => '1' # no change
+    }}
+    issue.reload
+
+    expect(ActionMailer::Base.deliveries.size).to eq 2
+    expect(issue.subject).to eq(new_subject)
+    expect(issue.project_ids).to be_empty
   end
 
   it "should put update should send a notification to members on other projects" do

--- a/spec/integration/issues_spec.rb
+++ b/spec/integration/issues_spec.rb
@@ -70,33 +70,6 @@ describe "Issues" do
     expect(issue.projects.collect(&:id)).to eq [2, 3]
   end
 
-  it "should only allow to add projects with issue creation permission" do
-    log_user('jsmith', 'jsmith')
-    get '/projects/1/issues/new', params: {:tracker_id => '1'}
-    expect(response).to be_successful
-    assert_template 'issues/new'
-    assert_select "p#projects_form", :count => 1
-
-    post '/projects/1/issues', params: {:tracker_id => "1",
-                                        :issue => {:start_date => "2006-12-26",
-                                                   :priority_id => "4",
-                                                   :subject => "new multiproject test issue",
-                                                   :category_id => "",
-                                                   :description => "new issue",
-                                                   :done_ratio => "0",
-                                                   :due_date => "",
-                                                   :assigned_to_id => "",
-                                                   :project_ids => [2, 3, 4] # user is not allowed to add permission on project 4
-                                        },
-                                        :custom_fields => {'2' => 'Value for field 2'}}
-
-    # find created issue
-    issue = Issue.find_by_subject("new multiproject test issue")
-    assert_kind_of Issue, issue
-    
-    expect(issue.projects.collect(&:id)).to eq [2, 3]
-  end
-
   it "should not be allowed to create issue with multiple projects" do
     Role.find(1).remove_permission!(:link_other_projects_to_issue) # Role for User:jsmith on Project:1
     log_user('jsmith', 'jsmith')


### PR DESCRIPTION
## V08
Ajout d'un contrôle de permission (:link_other_projects_to_issue) lorsqu'un utilisateur associe des projets à un ticket.